### PR TITLE
Display alert only for developers

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -50,7 +50,7 @@
 			
 			if(!is_null($context['alert'])) return;
 			
-		    if ($this->__filesNewer()) {
+		    if ($this->__filesNewer()) && Administration::instance()->Author->isDeveloper() {
 				$files = implode(__(" and "), array_map('__',array_map('ucfirst',$this->__filesNewer())));
 			
 		        if(count($this->__filesNewer()) == 1)


### PR DESCRIPTION
Authors shouldn't be aware of the sync files. These should be developer only.

What do you think?
