### PR TITLE
Symphony 2.5 compatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 This extension exports your Symphony database
 
-- Version: 1.11.2
+- Version: 1.12
 - Date: 15th October 2014
 - Requirements: Symphony 2.4 or above
 - Author: Nils Werner, nils.werner@gmail.com

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -50,7 +50,14 @@
 			
 			if(!is_null($context['alert'])) return;
 			
-		    if ($this->__filesNewer() && Administration::instance()->Author->isDeveloper()) {
+			// https://github.com/symphonycms/symphony-2/wiki/Migration-Guide-to-2.5-for-Developers#properties
+			if (is_callable(array('Symphony', 'Author'))) {
+				$author = Symphony::Author();
+			} else {
+				$author = Administration::instance()->Author;
+			}
+
+			if ($this->__filesNewer() && ($author instanceof Author && $author->isDeveloper()) ? true : false) {
 				$files = implode(__(" and "), array_map('__',array_map('ucfirst',$this->__filesNewer())));
 			
 		        if(count($this->__filesNewer()) == 1)

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,6 +15,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.12" date="2015-01-16" min="2.4">
+			- Symphony 2.5 compatibility
+		</release>
 		<release version="1.11.2" date="2014-10-15" min="2.4">
 			- Fixed syntax errors that rendered extension unusable.
 			- Fixed `mysql_real_escape_string` issue.


### PR DESCRIPTION
This fix a issue:

`Symphony Fatal Error: Call to a member function isDeveloper() on a non-object`.

https://github.com/symphonycms/symphony-2/wiki/Migration-Guide-to-2.5-for-Developers#properties

Cheers!
